### PR TITLE
Install command-line tool

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,4 +11,5 @@ setup(
     author_email='n.tivirikin@gmail.com',
     license="MIT",
     py_modules=['xenocanto'],
+    entry_points={"console_scripts": ["xeno-canto = xenocanto:main"]},
 )

--- a/xenocanto.py
+++ b/xenocanto.py
@@ -210,9 +210,7 @@ def gen_meta(path='dataset/audio/'):
     os.rename('data.txt', 'dataset/metadata/library.json')
 
 
-# Handles command line execution
-if __name__ == '__main__':
-    
+def main():
     act = sys.argv[1]
     params = sys.argv[2:]
  
@@ -236,3 +234,8 @@ if __name__ == '__main__':
             
     else:
         print("The command entered was not found, please consult the README for instructions and available commands.")
+
+
+# Handles command line execution
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
With this change, an executable named `xeno-canto` will be available to any user who has done `pip install xeno-canto`.

My understanding is that this project is first-and-foremost a command line utility for interacting with xeno-canto, and secondarily a python library that python programmers could import. So I think it would makes sense to emphasise the command-line usage, modifying the README accordingly (i.e. replace `python xenocanto.py ...` with `xeno-canto ...`).