### PR TITLE
Fix condition to skip existing files instead of breaking the loop

### DIFF
--- a/xenocanto.py
+++ b/xenocanto.py
@@ -92,7 +92,7 @@ def download(filt):
 
             # If the file exists in the directory, we will skip it
             elif os.path.exists(audio_path + audio_file):
-                break
+                continue
             print("Downloading " + track_id + ".mp3...")
             request.urlretrieve(url, audio_path + audio_file)
         page += 1


### PR DESCRIPTION
When downloading a large dataset of audio files, sometimes the process breaks due to network or server issues.
I've noticed the **-dl** option had the code to skip existing files but it wasn't downloading the missing ones.

Inspecting the code I could understand why: it was breaking out of the loop of files.

So I'm sending this small PR to fix this behavior